### PR TITLE
Fix auto_generate_script_path

### DIFF
--- a/metisse/utils/metisse_path.py
+++ b/metisse/utils/metisse_path.py
@@ -85,8 +85,7 @@ class ScriptPath(DevPath):
         caller_file_path = caller_frame.filename  # 获取调用该方法的文件路径
 
         _path = os.path.dirname(os.path.abspath(caller_file_path))
-        _path = os.path.join(_path, device_id)
-        script_path = ScriptPath(device_id, _path)
+        script_path = ScriptPath(_path, device_id)
         script_path.initialize_script_environment()
         return script_path
 

--- a/pytest_metisse/test_script_path.py
+++ b/pytest_metisse/test_script_path.py
@@ -1,0 +1,18 @@
+import os
+import shutil
+
+from metisse.settings import Settings as ST
+from metisse.utils.metisse_path import ScriptPath
+
+
+def test_auto_generate_script_path():
+    device_id = "pytest_device_auto"
+    script_path = ScriptPath.auto_generate_script_path(device_id)
+    expected_device_dir = os.path.join(os.path.dirname(__file__), device_id)
+    try:
+        assert script_path.device_id_path == os.path.abspath(expected_device_dir)
+        for sub in ST.SCRIPT_ENVIRONMENT_ROOT_PATH:
+            assert os.path.isdir(os.path.join(expected_device_dir, sub))
+    finally:
+        if os.path.exists(expected_device_dir):
+            shutil.rmtree(expected_device_dir)


### PR DESCRIPTION
## Summary
- fix ScriptPath.auto_generate_script_path parameter order
- add regression test for auto_generate_script_path

## Testing
- `make lint`
- `make local-test`

------
https://chatgpt.com/codex/tasks/task_e_6840f94e474c83318cd28d176e95bc3b