### PR TITLE
Add tests for ScriptPath and timestamp helper

### DIFF
--- a/pytest_metisse/test_metisse_small_methods.py
+++ b/pytest_metisse/test_metisse_small_methods.py
@@ -41,3 +41,10 @@ def test_execute_time_sleep(mock_sleep, metisse_basic_setup):
         mock_info.assert_called_with("execute_time_sleep : wait_time= %.2f", 1.5)
         mock_send.assert_called_with("execute_time_sleep method : \n wait_time= 1.50")
         mock_sleep.assert_called_once_with(1.5)
+
+
+@mock.patch("metisse.metisse.time.strftime", return_value="2025-01-01_00_00_00_")
+def test_get_time(mock_strftime, metisse_basic_setup):
+    result = metisse_basic_setup.get_time()
+    assert result == "2025-01-01_00_00_00_"
+    mock_strftime.assert_called_once()

--- a/pytest_metisse/test_script_path_functions.py
+++ b/pytest_metisse/test_script_path_functions.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+
+import pytest
+
+from metisse.params import SaveParams
+from metisse.utils.metisse_path import ScriptPath
+
+
+@pytest.fixture
+def script_path_setup(tmp_path):
+    sp = ScriptPath(str(tmp_path), "device")
+    yield sp
+    shutil.rmtree(str(tmp_path))
+
+
+def test_check_image_name_pngFormat(script_path_setup):
+    sp = script_path_setup
+    assert sp._check_image_name_pngFormat("img") == "img.png"
+    assert sp._check_image_name_pngFormat("icon.png") == "icon.png"
+
+
+def test_check_path_creates_directory(script_path_setup, tmp_path):
+    sp = script_path_setup
+    new_dir = tmp_path / "new" / "nested"
+    result = sp.check_path(str(new_dir))
+    assert os.path.isdir(new_dir)
+    assert result == str(new_dir)
+
+
+def test_get_save_image_path(script_path_setup):
+    sp = script_path_setup
+    params = SaveParams(
+        save_image_primary_dir="storage",
+        save_image_secondary_dir="sec",
+        save_image_name="img",
+    )
+    path = sp.get_save_image_path(params)
+    expected = os.path.join(sp.device_id_path, "storage", "sec", "img.png")
+    assert path == expected


### PR DESCRIPTION
## Summary
- expand test coverage for script path helpers
- test `_check_image_name_pngFormat`, `check_path`, and `get_save_image_path`
- verify `MetisseClass.get_time` output via patch

## Testing
- `make lint`
- `make local-test`


------
https://chatgpt.com/codex/tasks/task_e_6840fd9f2ce88331953c327fc0a33821