### PR TITLE
Increase Metisse tests coverage

### DIFF
--- a/pytest_metisse/test_default_tap.py
+++ b/pytest_metisse/test_default_tap.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import sys
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -74,6 +74,29 @@ def test_adb_default_tap(
 
     # Assert the return value of the default_tap method
     assert result, "check_image_recognition failed with basic params"
+
+
+@patch.object(MetisseClass, "check_image_recognition", return_value=False)
+@patch.object(MetisseClass, "tap")
+@patch.object(MetisseClass, "save_screenshot_compression")
+def test_adb_default_tap_fail(
+    mock_save_screenshot_compression,
+    mock_tap,
+    mock_check_image_recognition,
+    test_default_tap_setUp,
+):
+    params = ImageRecognitionParams(
+        template_image_name="test_template",
+        template_image_primary_dir="icon",
+        is_backup=True,
+    )
+
+    result = test_default_tap_setUp.default_tap(params)
+
+    mock_check_image_recognition.assert_called_with(params)
+    mock_tap.assert_not_called()
+    mock_save_screenshot_compression.assert_called_once()
+    assert result is False
 
 
 if __name__ == "__main__":

--- a/pytest_metisse/test_metisse_actions.py
+++ b/pytest_metisse/test_metisse_actions.py
@@ -123,3 +123,34 @@ def test_press_success_calls_swipe_and_logs(metisse_actions_setup):
             "adb_press method : \n (x,y) = (3, 4) \n pressing_time = 50"
         )
         m_sleep.assert_called()
+
+
+def test_screenshot_invalid_environment(metisse_actions_setup):
+    mc = metisse_actions_setup
+    mc._os_environment = "windows"
+    with mock.patch.object(mc._client, "screenshot") as m_shot:
+        with pytest.raises(RuntimeError):
+            mc.screenshot()
+        m_shot.assert_not_called()
+
+
+def test_tap_invokes_client_with_offset(metisse_actions_setup):
+    mc = metisse_actions_setup
+    with mock.patch.object(mc._client, "tap") as m_tap, mock.patch.object(
+        mc._logger, "info"
+    ) as m_info, mock.patch.object(
+        mc._ui_client, "send_log_to_ui"
+    ) as m_send, mock.patch(
+        "metisse.metisse.time.sleep"
+    ) as m_sleep:
+        mc.tap(
+            (10, 20),
+            tap_execute_counter_times=2,
+            tap_execute_wait_time=0.1,
+            tap_offset=(5, -5),
+        )
+        assert m_tap.call_count == 2
+        m_tap.assert_called_with((15, 15))
+        assert m_info.call_count == 2
+        assert m_send.call_count == 2
+        assert m_sleep.call_count == 2

--- a/pytest_metisse/test_metisse_small_methods.py
+++ b/pytest_metisse/test_metisse_small_methods.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from unittest import mock
 
@@ -48,3 +49,13 @@ def test_get_time(mock_strftime, metisse_basic_setup):
     result = metisse_basic_setup.get_time()
     assert result == "2025-01-01_00_00_00_"
     mock_strftime.assert_called_once()
+
+
+def _wrapper_for_current_path() -> str:
+    """Helper used to test ``get_current_path``."""
+    return MetisseClass.get_current_path()
+
+
+def test_get_current_path():
+    expected = os.path.dirname(os.path.abspath(__file__))
+    assert _wrapper_for_current_path() == expected


### PR DESCRIPTION
## Summary
- add helper and test for MetisseClass.get_current_path
- test default_tap failure branch
- test tap method behaviour
- test screenshot with invalid OS environment

## Testing
- `make lint`
- `make local-test`

------
https://chatgpt.com/codex/tasks/task_e_6841061681f0833181a56fe279daceff