### PR TITLE
Increase coverage of utility modules

### DIFF
--- a/pytest_metisse/test_metisse_log_file.py
+++ b/pytest_metisse/test_metisse_log_file.py
@@ -1,0 +1,15 @@
+import logging
+import os
+import tempfile
+
+from metisse.utils.metisse_log import MetisseLogger
+
+
+def test_set_log_file_creates_directory(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_path = log_dir / "test.log"
+    logger = MetisseLogger("test_logger", log_level=logging.DEBUG)
+    formatter = logging.Formatter("%(message)s")
+    logger.set_log_file(str(log_path), formatter)
+    assert log_path.exists(), "Log file was not created"
+    logger.close()

--- a/pytest_metisse/test_metisse_path_subdirs.py
+++ b/pytest_metisse/test_metisse_path_subdirs.py
@@ -1,0 +1,88 @@
+import os
+import shutil
+
+from metisse.params import ImageRecognitionParams, SaveParams
+from metisse.utils.metisse_path import ScriptPath
+
+
+def test_path_functions_with_subdirs(tmp_path):
+    sp = ScriptPath(str(tmp_path), "device")
+
+    img_params = ImageRecognitionParams(
+        screen_image_name="shot",
+        screen_image_primary_dir="temp_image",
+        screen_image_secondary_dir="sec",
+        screen_image_subdirs=["a", "b"],
+    )
+    screen_path = sp.get_screen_image_path(img_params)
+    expected_screen = os.path.join(
+        sp.device_id_path,
+        "temp_image",
+        "sec",
+        "a",
+        "b",
+        "shot.png",
+    )
+    assert screen_path == expected_screen
+
+    tmpl_params = ImageRecognitionParams(
+        template_image_name="tpl",
+        template_image_primary_dir="temp_image",
+        template_image_secondary_dir="sec",
+        template_image_subdirs=["c"],
+    )
+    template_path = sp.get_template_image_path(tmpl_params)
+    expected_template = os.path.join(
+        sp.device_id_path,
+        "temp_image",
+        "sec",
+        "c",
+        "tpl.png",
+    )
+    assert template_path == expected_template
+
+    tmpl_params2 = ImageRecognitionParams(
+        template_image_name="tpl2",
+        template_image_primary_dir="icon",
+        template_image_secondary_dir="sec2",
+        template_image_subdirs=["d"],
+    )
+    template_path2 = sp.get_template_image_path(tmpl_params2)
+    expected_template2 = os.path.join(
+        sp.absolute_path,
+        "icon",
+        "sec2",
+        "d",
+        "tpl2.png",
+    )
+    assert template_path2 == expected_template2
+
+    save_params = SaveParams(
+        load_image_name="shot",
+        load_image_secondary_dir="old",
+        load_image_subdirs=["l1"],
+        save_image_name="out",
+        save_image_secondary_dir="new",
+        save_image_subdirs=["s1"],
+    )
+    load_path = sp.get_load_image_path(save_params)
+    expected_load = os.path.join(
+        sp.device_id_path,
+        "temp_image",
+        "old",
+        "l1",
+        "shot.png",
+    )
+    assert load_path == expected_load
+
+    save_path = sp.get_save_image_path(save_params)
+    expected_save = os.path.join(
+        sp.device_id_path,
+        "storage",
+        "new",
+        "s1",
+        "out.png",
+    )
+    assert save_path == expected_save
+
+    shutil.rmtree(str(tmp_path))


### PR DESCRIPTION
## Summary
- add test for MetisseLogger.set_log_file
- cover ScriptPath path helpers with subdirectories

## Testing
- `make lint`
- `make local-test`

------
https://chatgpt.com/codex/tasks/task_e_68410d51910c8331aca73ff20f87ae1f