### PR TITLE
Increase test coverage

### DIFF
--- a/pytest_metisse/test_client_base.py
+++ b/pytest_metisse/test_client_base.py
@@ -1,0 +1,21 @@
+import pytest
+
+from metisse.clients.client import Client
+
+
+class DummyClient(Client):
+    def screenshot(self, save_screenshot_path: str) -> None:
+        return super().screenshot(save_screenshot_path)
+
+    def tap(self, coordinates):
+        return super().tap(coordinates)
+
+    def swipe(self, start_coordinates, end_coordinates, swiping_time):
+        return super().swipe(start_coordinates, end_coordinates, swiping_time)
+
+
+def test_client_base_methods_execute():
+    dummy = DummyClient()
+    assert dummy.screenshot("img.png") is None
+    assert dummy.tap((1, 2)) is None
+    assert dummy.swipe((1, 1), (2, 2), 100) is None

--- a/pytest_metisse/test_generate_example_funcs.py
+++ b/pytest_metisse/test_generate_example_funcs.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+from metisse.example import generate_example
+
+
+def _wrapper_path() -> str:
+    return generate_example.get_current_path()
+
+
+def test_get_current_path_func():
+    expected = os.path.dirname(os.path.abspath(__file__))
+    assert _wrapper_path() == expected
+
+
+def test_copy_images_and_ui(tmp_path):
+    src_img = tmp_path / "src_img"
+    src_ui = tmp_path / "src_ui"
+    dest_img = tmp_path / "dest_img"
+    dest_ui = tmp_path / "dest_ui"
+    src_img.mkdir()
+    src_ui.mkdir()
+    (src_img / "a.png").write_text("data")
+    (src_img / "b.txt").write_text("other")
+    (src_ui / "main.gui").write_text("ui")
+    generate_example.copy_images(str(src_img), str(dest_img))
+    generate_example.copy_ui(str(src_ui), str(dest_ui))
+    assert (dest_img / "a.png").exists()
+    assert not (dest_img / "b.txt").exists()
+    assert (dest_ui / "main.gui").exists()


### PR DESCRIPTION
## Summary
- add tests for the abstract Client base class
- add tests for helper functions in generate_example

## Testing
- `make lint`
- `make local-test`

------
https://chatgpt.com/codex/tasks/task_e_6841112228808331811534f0db8d70b0